### PR TITLE
更正快速上手指南中template模板语法错误

### DIFF
--- a/QUICK.md
+++ b/QUICK.md
@@ -346,7 +346,7 @@ python setup.py sdist install
     {% extends 'admin/index.html' %}
     {% load static %}
 
-    {%block head}
+    {% block head %}
         {{ block.super }}
         ..此处写你的代码
     {% endblock %}
@@ -374,7 +374,7 @@ python setup.py sdist install
     {% extends 'admin/index.html' %}
     {% load static %}
 
-    {%block head}
+    {% block head %}
         {{ block.super }}
         ..此处写你的代码
     {% endblock %}


### PR DESCRIPTION
更正快速上手指南中template模板语法错误 '{%block'的地方