### PR TITLE
Navigation back from Detail to List with filters preserved

### DIFF
--- a/simpleui/templatetags/simpletags.py
+++ b/simpleui/templatetags/simpletags.py
@@ -18,6 +18,7 @@ from django.utils.encoding import force_text
 from django.utils.functional import Promise
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 
 register = template.Library()
 
@@ -26,7 +27,9 @@ from django.utils.translation import gettext_lazy as _
 
 if PY_VER != '2':
     from importlib import reload
-
+    from urllib.parse import parse_qsl
+else:
+    from urlparse import parse_qsl
 
 def unicode_to_str(u, encoding='utf-8'):
     if PY_VER != '2':
@@ -455,7 +458,12 @@ def get_model_url(context):
     # reverse()
     opts = context.get('opts')
     key = 'admin:{}_{}_changelist'.format(opts.app_label, opts.model_name)
-    return reverse(key)
+    url = reverse(key)
+    preserved_filters = dict(parse_qsl(context.get('preserved_filters')))
+    if '_changelist_filters' in preserved_filters:
+        preserved_filters = preserved_filters['_changelist_filters']
+        url = add_preserved_filters({'preserved_filters': preserved_filters, 'opts': opts}, url)
+    return url
 
 
 @register.simple_tag


### PR DESCRIPTION
now get_model_url returns url with applied filters (if they was) on List view