### PR TITLE
Fixes issue with Vue breaking on log entries resembling mustache temp…

### DIFF
--- a/simpleui/templates/admin/home.html
+++ b/simpleui/templates/admin/home.html
@@ -82,7 +82,7 @@
                     <el-timeline-item timestamp="{{ entry.action_time }}" placement="top">
                         <el-card>
                             <p>{{ entry.user }} {{ entry.action_time }}</p>
-                            <h4>{{ entry.content_type }}: {{ entry }}</h4>
+                            <h4 v-pre="true">{{ entry.content_type }}: {{ entry }}</h4>
                         </el-card>
                     </el-timeline-item>
                     {% endfor %}


### PR DESCRIPTION
django-simpleui breaks when Admin log entries contain mustache markup (`{{ some text }}`).
It simply displays empty page and it was very hard to diagnose this problem.

Hence a simple solution.