### PR TITLE
修复打包后的文件缺失templatetags而导致的页面异常

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include simpleui/ *
 recursive-include simpleui/static *
 recursive-include simpleui/templates *
+recursive-include simpleui/templatetags *


### PR DESCRIPTION
AT
问题是在最新的pip安装包里发现的。 merge后，需要重新打包。