### PR TITLE
fix ajax url bug

### DIFF
--- a/simpleui/templatetags/simpletags.py
+++ b/simpleui/templatetags/simpletags.py
@@ -499,7 +499,7 @@ def get_model_ajax_url(context):
     opts = context.get("opts")
     request = context.get("request")
 
-    key = "{}:{}_{}_changelist".format(
+    key = "{}:{}_{}_ajax".format(
         get_current_app(request), opts.app_label, opts.model_name
     )
     try:


### PR DESCRIPTION
自定义按钮使用layer时，ajax回调函数不执行自定义actions代码的bug问题。

该问题可通过官方demo复现: [员工管理模块下的-->弹出对话框输入按钮，弹出窗体输入内容后，提示内容为空，附件显示了效果
<img width="786" alt="simpleui_issue" src="https://user-images.githubusercontent.com/10334878/135276980-692321b1-14c4-49b6-87b3-24c3fbcedf41.png">

@baletu @kicer
 