### PR TITLE
新增layer文件上传的文件类型限制功能

### DIFF
--- a/simpleui/templates/admin/actions.html
+++ b/simpleui/templates/admin/actions.html
@@ -180,7 +180,7 @@
 
                 </el-radio-group>
 
-                <input v-else-if="item.type=='file'" type="file" :ref="item.key"/>
+                <input v-else-if="item.type=='file'" type="file" :ref="item.key" :accept="item.accept?item.accept:'*'"/>
 
                 <el-input v-else v-model="item.value" :type="item.type" :style="{width:item.width}"
                           :size="item.size"></el-input>


### PR DESCRIPTION
为[自定义按钮&Action](https://simpleui.72wo.com/docs/simpleui/QUICK.html#%E8%87%AA%E5%AE%9A%E4%B9%89%E6%8C%89%E9%92%AE-action)的[layer 文件上传](https://simpleui.72wo.com/docs/simpleui/QUICK.html#layer-%E6%96%87%E4%BB%B6%E4%B8%8A%E4%BC%A0)功能添加accept字段限制接受的文件类型。

使用方式如下：
```python

@admin.register(Layer)
class LayerAdmin(AjaxAdmin):
    actions = ('upload_file',)

    def upload_file(self, request, queryset):
        # 这里的upload 就是和params中配置的key一样
        upload= request.FILES['upload']
        print(upload)
        pass

    upload_file.short_description = '文件上传对话框'
    upload_file.type = 'success'
    upload_file.icon = 'el-icon-upload'
    upload_file.enable = True

    upload_file.layer = {
        'params': [{
            'type': 'file',
            'key': 'upload',
            'label': '文件',
            # 若无此字段，默认接受所有文件类型
            'accept': 'image/png, image/jpeg'
        }]
    }
```