### PR TITLE
日期选择器格式化

### DIFF
--- a/simpleui/templates/admin/actions.html
+++ b/simpleui/templates/admin/actions.html
@@ -115,6 +115,8 @@
                         v-else-if="item.type=='date'"
                         :style="{width:item.width}"
                         :size="item.size"
+                        :format="item.format"
+                        :value-format="item.value_format"
                         v-model="item.value"
                         type="date">
                 </el-date-picker>
@@ -123,6 +125,8 @@
                         v-else-if="item.type=='datetime'"
                         :style="{width:item.width}"
                         :size="item.size"
+                        :format="item.format"
+                        :value-format="item.value_format"
                         v-model="item.value"
                         type="datetime">
                 </el-date-picker>


### PR DESCRIPTION
格式化日期选择器的显示和上传
```python
layer_input.layer = {
    'params': [
        {
            'type': 'date',
            'key': 'date',
            'label': '日期',
            # 日期显示格式
            'format': 'yyyy 年 MM 月 dd 日',
            # 日期上传格式
            'value_format': 'yyyy-MM-dd',
        },
    ],
}
```

更多内容详见element-ui[文档](https://element.eleme.cn/#/zh-CN/component/date-picker#ri-qi-ge-shi)