### PR TITLE
feat: dialogConfirmDisabled 避免重复提交

### DIFF
--- a/simpleui/templates/admin/actions.html
+++ b/simpleui/templates/admin/actions.html
@@ -188,7 +188,8 @@
         </el-form>
 
         <span slot="footer" class="dialog-footer">
-            <el-button type="primary" @click="layerSubmit()" v-text="layer.confirm_button||'确定'"></el-button>
+            <el-button type="primary" @click="layerSubmit()" v-text="layer.confirm_button||'确定'"
+                       :disabled="dialogConfirmDisabled" v-loading="dialogConfirmDisabled"></el-button>
             <el-button @click="visible = false" v-text="layer.cancel_button||'取消'"></el-button>
         </span>
     </el-dialog>
@@ -206,7 +207,8 @@
             params: [],
             layer: {},
             rules: [],
-            action: ''
+            action: '',
+            dialogConfirmDisabled: false
         },
         methods: {
             layerSubmit() {
@@ -241,11 +243,12 @@
                         data.append(item.key, item.value);
                     }
                 }
-
+                this.dialogConfirmDisabled = true;
                 axios.post('{% get_model_ajax_url %}'+window.location.search, data).then(res => {
                     if (res.data.status === 'redirect') {
                         self.visible = false;
                         window.location.href = res.data.url;
+                        this.dialogConfirmDisabled = false;
                         return;
                     }
                     if (res.data.status == 'success') {
@@ -257,6 +260,7 @@
                         message: res.data.msg,
                         type: res.data.status
                     });
+                    this.dialogConfirmDisabled = false;
                 }).catch(err => self.$message.error(err));
             }
         }


### PR DESCRIPTION
# 现状：
action layer 为各个业务系统带来灵活性，可以自定义业务表单。不过当自定义dialog表单时，提交按钮可以多次点击，会产生重复提交数据的情况，而且后端处理逻辑如果比较耗时，前端没有任何友好提示。
# 解决：
点击dialog提交按钮，添加loading与disable属性

# 案例代码：
```python
    actions = ('layer_input',)

    def layer_input(self, request, queryset):
        url = request.POST.get("url")
        # handle url ......
        return JsonResponse(data={'status': 'success', 'msg': '处理成功！'})

    layer_input.short_description = '数据导入'
    layer_input.type = 'success'
    layer_input.icon = 'el-icon-s-promotion'
    layer_input.layer = {
        'title': '数据导入',
        'tips': '数据导入， 请输入链接地址',
        'confirm_button': '确认提交',
        'cancel_button': '取消',
        'width': '40%',
        'labelWidth': "80px",
        'params': [{
            'type': 'input',
            'key': 'url',
            'label': '地址',
            'require': True
        }]
    }
```
### 原始效果：
<img width="1303" alt="image" src="https://github.com/newpanjing/simpleui/assets/38744096/39b8c71d-fe01-4091-8f01-df875bac2ae5">


### 更正后效果：
<img width="1279" alt="image" src="https://github.com/newpanjing/simpleui/assets/38744096/f40ef759-d18d-49c1-8fbe-9df9b45ae7e2">
<img width="1281" alt="image" src="https://github.com/newpanjing/simpleui/assets/38744096/5049b8b6-ff78-4f53-916b-38a2f4cf95d4">

