### PR TITLE
Avoid overwrite simpleui menu configure

### DIFF
--- a/simpleui/templatetags/simpletags.py
+++ b/simpleui/templatetags/simpletags.py
@@ -230,6 +230,8 @@ def menus(context, _get_config=None):
     config = _get_config('SIMPLEUI_CONFIG')
     if not config:
         config = {}
+    else:
+        config = config.copy()
 
     if config.get('dynamic', False) is True:
         config = _import_reload(_get_config('DJANGO_SETTINGS_MODULE')).SIMPLEUI_CONFIG


### PR DESCRIPTION
I observe a problem that consistently has minimal privilege, even for superusers, when testing the access control feature.

`if has_permission_in_config(config):
        config["menus"] = get_filtered_menus(config["menus"], context.request.user.get_all_permissions())
`

Please help me review this commit.
Thanks