### PR TITLE
解决勾选记录后，点击 导入/导出 按钮，触发 action 请求，导致 导入/导出 请求中断，并提示 未选择动作

### DIFF
--- a/simpleui/templates/admin/actions.html
+++ b/simpleui/templates/admin/actions.html
@@ -412,6 +412,13 @@
             var data_name = $(this).attr('data-name');
             var _vue = new Vue();
 
+            // 解决勾选记录后，点击 导入/导出 按钮，触发 action 请求，导致 导入/导出 请求中断，并提示 未选择动作
+            if (data_name === 'export_admin_action' || data_name === 'import_admin_action' ||
+                data_name === 'export_admin_action') {
+                e.preventDefault(); // 阻止默认的表单提交
+                return;
+            }
+
             //这边处理弹出层对话框
             if (eid) {
                 for (var i in _action.customButton) {


### PR DESCRIPTION
## 问题描述

在当前版本中，用户在勾选记录后点击"导入"或"导出"按钮时，会触发一个不必要的 action 请求。这导致了以下问题：

1. 导入/导出操作被中断
2. 用户收到"未选择动作"的错误提示
3. 影响了用户体验，增加了操作的复杂性

## 原因分析

经过代码审查，发现问题出在 `actions.html` 文件中的 JavaScript 代码。当前实现对所有操作按钮使用了统一的事件处理逻辑，没有对导入/导出操作进行特殊处理。

## 解决方案

1. 在事件处理函数中增加对导入/导出操作的特殊判断，对导入导出操作，不进行 action 请求

## 修改内容

- 更新 `actions.html` 文件中的 JavaScript 代码：对导入导出操作，不进行 action 请求

## 收益

1. 修复了导入/导出功能的错误行为
2. 提升了用户体验，减少了操作中的困惑和错误
3. 保持了其他操作按钮的原有功能不变

## 测试

- 已在本地环境进行了全面测试，确保修改不会影响其他功能
- 测试用例包括：勾选单个记录、多个记录、全选记录后的导入/导出操作
- 验证了其他操作按钮（如删除、编辑等）的功能保持不变