### PR TITLE
Update menu.js-更新侧边菜单折叠时菜单名称不显示

### DIFF
--- a/simpleui/static/admin/simpleui-x/js/menu.js
+++ b/simpleui/static/admin/simpleui-x/js/menu.js
@@ -10,12 +10,12 @@ Vue.component('sub-menu', {
             <template v-for="(item,i) in menus" :key="item.eid">
                 <el-menu-item  :index="item.eid" v-if="!item.models" @click="openTab(item,item.eid)">
                     <i :class="'menu-icon '+item.icon"></i>
-                    <span v-show="!fold" slot="title" v-text="item.name"></span>
+                    <span>{{item.name}}</span>
                 </el-menu-item>
                 <el-submenu :index="item.eid" v-else>
                     <template slot="title">
                         <i :class="'menu-icon '+item.icon"></i>
-                        <span v-show="!fold" v-text="item.name"></span>
+                        <span v-show="!fold">{{item.name}}</span>
                     </template>
                    <sub-menu :menus="item.models"></sub-menu>
                 </el-submenu>


### PR DESCRIPTION
解决侧边菜单折叠时，鼠标放置菜单中时，菜单名称不显示问题