### PR TITLE
引用了TabularInlineStyle关联数据，后台模板弹性布局所有值挤在了一列，调整了has_original下布局，选择框放大适配

### DIFF
--- a/simpleui/static/admin/simpleui-x/css/base.css
+++ b/simpleui/static/admin/simpleui-x/css/base.css
@@ -110,6 +110,27 @@ tbody tr:hover th {
   display: flex;
   align-items: center;
 }
+.form-row.has_original p{
+  display:none
+}
+tbody .has_original td{
+  padding-top: 0.5em !important;
+}
+input[type="checkbox"] {
+    width: 20px;
+    height: 20px;   
+    transform: scale(1.2); 
+    transform-origin: left center; 
+}
+.form-row .delete{
+  display: flex;
+}
+.form-row.has_original .delete{
+  padding-left: 0.7em;
+  padding-top: 1em !important;
+  padding-bottom: 1em !important;
+
+}
 .form-row .fileBox {
   flex: 1;
 }


### PR DESCRIPTION
样式中隐藏了源数据一列，
调整源数据行与新一行样式一致，
选择框内边距加大，保持一行选中效果，
原django删除按钮样式对齐，选择框放大调整与删除按钮大小一致。